### PR TITLE
Fixes Asset Controller to use photo_model

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -63,7 +63,7 @@ class AssetsController < ApplicationController
   private
 
   def asset_params
-    params.permit(:figure_num, :asset_description, :order_num, :landscape, :portrait, :demonstrative, :decorative, :frame_num, :instructions, :photographer, :frame_range, :parts, :equipment, :model, :location_of_shoot, :date_of_shoot, :time_of_shoot, :image)
+    params.permit(:figure_num, :asset_description, :order_num, :landscape, :portrait, :demonstrative, :decorative, :frame_num, :instructions, :photographer, :frame_range, :parts, :equipment, :photo_model, :location_of_shoot, :date_of_shoot, :time_of_shoot, :image)
   end
 
   def forbidden


### PR DESCRIPTION
Fixes Asset Controller to use :photo_model instead of :model. 