### PR TITLE
Changes strong params to allow :image again.

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -120,7 +120,7 @@ class PhotosController < ApplicationController
   end
 
   def photo_params
-    params.permit(:frame_num, :liked, :disliked, :selected, :asset_id, :selected_photo, {sample_photos: []})
+    params.permit(:frame_num, :liked, :disliked, :selected, :asset_id, :selected_photo, :image)
   end
 
 end


### PR DESCRIPTION
More remnants of the rabbit-hole logic. Changes strong params to allow :image again instead of {sample_photos: []}