### PR TITLE
Fixes 500 error when deleting projects.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,7 +10,7 @@ class Project < ApplicationRecord
 
   has_many :assets
 
-  has_many :photos, dependent: :delete_all
+  has_many :photos, through: :assets
 
   has_many :comments, dependent: :destroy
   has_many :left_comments, as: :commentable, class_name: 'Comment', dependent: :destroy


### PR DESCRIPTION
Fixes 500 error when deleting projects. It was trying to find project.id for photos.