### PR TITLE
Fix selected photos not toggling properly

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -42,6 +42,7 @@ class PhotosController < ApplicationController
     if editor
       if @photo
         @selected_photo.update(selected: false) if @selected_photo
+        @selected_photo.save
         @photo.selected = true
         if @photo.save
            render json: @photo #["Photo #{@photo.frame_num} set as the selected photo for Project #{@project.project_num}, figure #{@asset.figure_num} successfully!"]


### PR DESCRIPTION
Saves previously selected photo. selected was getting set to false, but it wasn't saving after setting the new photo to selected.